### PR TITLE
Update howto-vault-e2e.md

### DIFF
--- a/docs/operator/howto-vault-e2e.md
+++ b/docs/operator/howto-vault-e2e.md
@@ -127,7 +127,7 @@ spec:
     - name: wildcard-ssl
       secret:
         defaultMode: 420
-        secretName: wildcard.examlpe.com
+        secretName: wildcard.example.com
 
   volumeMounts:
     - name: wildcard-ssl


### PR DESCRIPTION
Fixed a typo in the yaml for mounting the wildcard-ssl into the vault pod as a secret.